### PR TITLE
Expose Patricia Tree Module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
 extern crate bitcoin;
 
 pub mod blockchain;
-mod patricia_tree;
+pub mod patricia_tree;


### PR DESCRIPTION
patricia_tree module should be exposed as public for usage.